### PR TITLE
build: isolate build process

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,21 @@ services:
     environment:
       - AWS_LAMBDA_RUNTIME_API=localhost:9000
     command: [ "scripts/dev/start.sh" ]
+
+  build-release-prod:
+    image: craftarc/axel:dependencies
+    build:
+      context: .
+      dockerfile: dockerfile/dependencies.Dockerfile
+    volumes:
+      - .:/axel
+    command: [ "scripts/build-release.sh", "prod" ]
+
+  build-release-test:
+    image: craftarc/axel:dependencies
+    build:
+      context: .
+      dockerfile: dockerfile/dependencies.Dockerfile
+    volumes:
+      - .:/axel
+    command: [ "scripts/build-release.sh", "test" ]

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Build script for prod
+
+# Set CMake arguments here
+cmake_args='-G Ninja -DCMAKE_BUILD_TYPE=Release'
+
+echo ">> Environment is: $1"
+if [ "$1" = 'prod' ]; then
+  cmake_args+=' -DAXEL_TEST=NO'
+elif [ "$1" = 'test' ]; then # If 'env' is not defined then default to building for test environment
+  cmake_args+=' -DAXEL_TEST=YES'
+else
+  echo "Invalid argument for 'env'. Exiting..."
+  exit 1
+fi
+
+echo ">> Current working directory: $(pwd)"
+
+echo ">> Building Axel..."
+mkdir -p build
+cmake -B build -S . ${cmake_args} # CMake configuration setup
+cmake --build build --target all --target aws-lambda-package-main
+echo ">> Compilation complete"
+
+bash
+

--- a/scripts/dev/start.sh
+++ b/scripts/dev/start.sh
@@ -4,7 +4,7 @@ echo ">> Inside container"
 set -euo pipefail
 
 # Set CMake arguments here
-cmake_args='-G Ninja -DAXEL_TEST=YES -DCMAKE_BUILD_TYPE=Debug'
+cmake_args='-G Ninja -DCMAKE_BUILD_TYPE=Debug'
 
 # Cleanup function that write logs to mounted project root
 signal_handler() {
@@ -48,12 +48,11 @@ fi
 
 # Build updated executables
 
-## Compile and build
+# Compile and build
 mkdir -p build
 cmake -B build -S . ${cmake_args} # CMake configuration setup
-cmake --build build --clean-first --target all --target aws-lambda-package-main
+cmake --build build --target all --target aws-lambda-package-main
 echo ">> Compilation complete"
-
 
 # Start RIE in background
 echo ">> Starting RIE and invoking the handler..."


### PR DESCRIPTION
Move the building process (ie. cmake && ninja) into a separate bash script (scripts/build.sh).

Add 'build' service to docker-compose. Running this builds a Release build targeting production servers. docker compose up build-release-test to build a Release build targeting testing servers (for use in staging)